### PR TITLE
Add derived column for better visibility into database spans

### DIFF
--- a/environment_derived_columns/db_system_or_type.tf
+++ b/environment_derived_columns/db_system_or_type.tf
@@ -1,0 +1,38 @@
+####################################################
+# Ensure Columns Exist That the DC Will Use
+####################################################
+resource "honeycombio_column" "db-system" {
+  count = var.create_required_columns_dataset ? 1 : 0
+  key_name = "db.system"
+  type = "string"
+  dataset = var.required_columns_dataset_name
+}
+
+resource "honeycombio_column" "db-type" {
+  count = var.create_required_columns_dataset ? 1 : 0
+  key_name = "db.type"
+  type = "string"
+  dataset = var.required_columns_dataset_name
+}
+
+####################################################
+# Create the Derived Column
+####################################################
+resource "honeycombio_derived_column" "dc_db_system_or_type" {
+  alias       = "dc_db_system_or_type"
+  dataset     = "__all__"
+  description = "Returns the database system if available or the database type if available"
+  expression  = templatefile("${path.module}/templates/db_system_or_type.tftpl", {})
+  depends_on  = [
+    honeycombio_column.db-system,
+    honeycombio_column.db-type,
+  ]
+}
+
+####################################################
+# Output the Derived Column ID for Other Modules
+####################################################
+
+output "dc_db_system_or_type" {
+  value = honeycombio_derived_column.dc_db_system_or_type.alias
+}

--- a/environment_derived_columns/templates/db_system_or_type.tftpl
+++ b/environment_derived_columns/templates/db_system_or_type.tftpl
@@ -1,0 +1,5 @@
+COALESCE(
+  IF(EXISTS($db.system), $db.system),
+  IF(EXISTS($db.type), $db.type),
+  null
+)

--- a/environment_queries/traces_by_db_system.tf
+++ b/environment_queries/traces_by_db_system.tf
@@ -1,41 +1,30 @@
 ####################################################
 # Ensure Columns Exist That the Query Will Use
 ####################################################
-resource "honeycombio_column" "db-system" {
-  count = var.create_required_columns_dataset ? 1 : 0
-  key_name = "db.system"
-  type = "string"
-  dataset = var.required_columns_dataset_name
-}
+
+# Using derived columns, or already defined columns
 
 ####################################################
 # Define the Query Specification
 ####################################################
 data "honeycombio_query_specification" "count_of_traces_by_db_system" {
   calculation {
-    op     = "COUNT_DISTINCT"
-    column = "trace.trace_id"
+    op     = "COUNT"
   }
 
   filter {
-    column = "db.system"
+    column = "dc_db_system_or_type"
     op     = "exists"
   }
 
-  breakdowns = [ "db.system" ]
+  breakdowns = [ "dc_db_system_or_type" ]
 
   order {
-    op     = "COUNT_DISTINCT"
-    column = "trace.trace_id"
+    op     = "COUNT"
     order  = "descending"
   }
 
   time_range = var.query_time_range
-
-  depends_on = [
-    honeycombio_column.trace-trace_id,
-    honeycombio_column.db-system,
-  ]
 }
 
 ####################################################
@@ -51,7 +40,7 @@ resource "honeycombio_query" "count_of_traces_by_db_system" {
 ################################################################
 resource "honeycombio_query_annotation" "count_of_traces_by_db_system" {
   dataset     = "__all__"
-  description = "Displays the number of trace interacting with a Database where the [type of database](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#connection-level-attributes) is included in the span attributes."
+  description = "Displays the number of spans interacting with a Database where the [type of database](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#connection-level-attributes) is included in the span attributes."
   name        = "Database Systems Spans"
   query_id    = honeycombio_query.count_of_traces_by_db_system.id
 }


### PR DESCRIPTION
## Short description of the changes

This basically updates the `db.system` query in the `All Services Board` to use a derived column which will output the `db.system` or `db.type` field when a database call is being made.  The `db .system` field is preferred, but some libraries/auto-instrumenters don't populate that (looking at you Elixer), so it will fill in `db.type` when system is unavailable.

