### PR TITLE
Update TF tests to not create columns or datasets

### DIFF
--- a/.github/workflows/test-terraform-module.yml
+++ b/.github/workflows/test-terraform-module.yml
@@ -34,5 +34,5 @@ jobs:
       - name: Terraform Apply
         run: terraform apply -auto-approve -no-color -var "required_columns_dataset_name=${{ env.DSETNAME }}"
 
-      # - name: Terraform Destroy
-      #   run: terraform destroy -auto-approve -no-color -var "required_columns_dataset_name=${{ env.DSETNAME }}"
+      - name: Terraform Destroy
+        run: terraform destroy -auto-approve -no-color -var "required_columns_dataset_name=${{ env.DSETNAME }}"

--- a/tests/opentelemetry-starter-pack-test.tf
+++ b/tests/opentelemetry-starter-pack-test.tf
@@ -6,8 +6,8 @@ module "honeycombio-opentelemetry-starter-pack" {
   max_long_duration                    = 15000
   min_long_duration                    = 2000
   query_time_range                     = 604800
-  create_required_columns              = true
-  create_required_columns_dataset      = true
+  create_required_columns              = false
+  create_required_columns_dataset      = false
   required_columns_dataset_name        = var.required_columns_dataset_name
 }
 


### PR DESCRIPTION
## Short description of the changes

This updates the Terraform tests to not create columns or datasets by default, so that running terraform destroy won't have issues with trying to delete columns that don't have 

## How to verify that this has the expected result

tests pass automatically again, with the terraform destroy step running successfully as well.