### PR TITLE
Utilize the new honeycombio_columns datasource to auto-create only the missing columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 .terraform.*
 *.tfstate
 *.tfstate.backup
+terraform.tfvars
 .DS_Store

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ resource "honeycombio_dataset" "required-columns-dataset" {
 }
 
 data "honeycombio_columns" "all" {
+  count = var.create_required_columns_dataset && var.create_required_columns ? 1 : 0
   dataset = var.required_columns_dataset_name
 }
 

--- a/main.tf
+++ b/main.tf
@@ -36,14 +36,14 @@ locals {
     "telemetry.sdk.name"     = "string",
   }
 
-  cols_to_create = setsubtract(keys(local.required_columns), data.honeycombio_columns.all.names)
+  cols_to_create = setsubtract(keys(local.required_columns), data.honeycombio_columns.all.names) || []
 
   required_rpc_columns = {
     "rpc.grpc.status_code" = "integer",
     "rpc.system"           = "string",
   }
 
-  rpccols_to_create = setsubtract(keys(local.required_rpc_columns), data.honeycombio_columns.all.names)
+  rpccols_to_create = setsubtract(keys(local.required_rpc_columns), data.honeycombio_columns.all.names) || []
 }
 
 output "columns_created" {

--- a/main.tf
+++ b/main.tf
@@ -36,14 +36,14 @@ locals {
     "telemetry.sdk.name"     = "string",
   }
 
-  cols_to_create = setsubtract(keys(local.required_columns), data.honeycombio_columns.all[0].names) || []
+  cols_to_create = setsubtract(keys(local.required_columns), data.honeycombio_columns.all[0].names)
 
   required_rpc_columns = {
     "rpc.grpc.status_code" = "integer",
     "rpc.system"           = "string",
   }
 
-  rpccols_to_create = setsubtract(keys(local.required_rpc_columns), data.honeycombio_columns.all[0].names) || []
+  rpccols_to_create = setsubtract(keys(local.required_rpc_columns), data.honeycombio_columns.all[0].names)
 }
 
 output "columns_created" {

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "honeycombio_dataset" "required-columns-dataset" {
 }
 
 data "honeycombio_columns" "all" {
-  count = var.create_required_columns_dataset && var.create_required_columns ? 1 : 0
+  count   = var.create_required_columns_dataset && var.create_required_columns ? 1 : 0
   dataset = var.required_columns_dataset_name
 }
 

--- a/main.tf
+++ b/main.tf
@@ -36,14 +36,14 @@ locals {
     "telemetry.sdk.name"     = "string",
   }
 
-  cols_to_create = setsubtract(keys(local.required_columns), data.honeycombio_columns.all.names) || []
+  cols_to_create = setsubtract(keys(local.required_columns), data.honeycombio_columns.all[0].names) || []
 
   required_rpc_columns = {
     "rpc.grpc.status_code" = "integer",
     "rpc.system"           = "string",
   }
 
-  rpccols_to_create = setsubtract(keys(local.required_rpc_columns), data.honeycombio_columns.all.names) || []
+  rpccols_to_create = setsubtract(keys(local.required_rpc_columns), data.honeycombio_columns.all[0].names) || []
 }
 
 output "columns_created" {

--- a/modules/environment_boards/versions.tf
+++ b/modules/environment_boards/versions.tf
@@ -1,9 +1,7 @@
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     honeycombio = {
       source  = "honeycombio/honeycombio"
-      version = ">= 0.12.0"
     }
   }
 }

--- a/modules/environment_derived_columns/versions.tf
+++ b/modules/environment_derived_columns/versions.tf
@@ -1,9 +1,7 @@
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     honeycombio = {
       source  = "honeycombio/honeycombio"
-      version = ">= 0.12.0"
     }
   }
 }

--- a/modules/environment_queries/versions.tf
+++ b/modules/environment_queries/versions.tf
@@ -1,9 +1,7 @@
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     honeycombio = {
       source  = "honeycombio/honeycombio"
-      version = ">= 0.12.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "create_required_columns_dataset" {
 variable "create_required_columns" {
   description = "Create columns that are required by the OpenTelemetry Starter Pack. If used, you must set the `required_columns_dataset_name` variable to determine where the columns will be created"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "required_columns_dataset_name" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
   required_providers {
     honeycombio = {
       source  = "honeycombio/honeycombio"
-      version = ">= 0.12.0"
+      version = ">= 0.15.0"
     }
   }
 }


### PR DESCRIPTION
## Short description of the changes
This PR utilizes the new `honeycombio_columns` data source (note: [PR still pending](https://github.com/honeycombio/terraform-provider-honeycombio/pull/297) ) to determine the list of already-existing columns, and only create the needed ones.  A little bit of "Terraform programming" to `setsubtract()` the list of existing columns from the list of required columns and badabing! 

As a tiny debugging helper, I added a `columns_created` output which helps you see wh

## How to verify that this has the expected result
Create a dataset that has some or all of the required_columns already created.  Run `terraform plan` on this PR and you should see:
```
  + columns_created        = []
```
and no plan to create any already-existing columns.